### PR TITLE
Add demo data button to templates

### DIFF
--- a/DEMO_DATA_IMPLEMENTATION.md
+++ b/DEMO_DATA_IMPLEMENTATION.md
@@ -1,0 +1,126 @@
+# Demo Data Implementation Summary
+
+## Overview
+A comprehensive demo data system has been implemented across all templates in the `/app/templates` directory to enable quick and easy testing by filling in all form fields with realistic demo data.
+
+## Implementation Details
+
+### Core Component
+- **File**: `app/utils/demoDataHelper.js`
+- **Class**: `DemoDataHelper`
+- **Purpose**: Provides demo data generation and form population functionality
+
+### Key Features
+
+#### 1. Demo Data Button
+- A floating "Fill Demo Data" button is added to each template
+- Positioned in the top-right corner with Flask icon
+- Styled with hover effects and proper z-index
+
+#### 2. Field Type Support
+The system supports all field types used across templates:
+- **Text fields**: Auto-populated with realistic sample data
+- **Select/Dropdown fields**: Selects first valid option
+- **Checkboxes**: Checks the first option in checkbox groups
+- **Rich text/Quill editors**: Populated with formatted HTML content
+- **Date fields**: Set to current date
+- **Email fields**: Populated with sample email addresses
+- **Hidden fields**: Skipped appropriately
+
+#### 3. Smart Demo Data
+The helper includes template-specific demo data for common fields:
+- District names (e.g., "Fairfax County Public Schools")
+- User information (names, usernames, emails)
+- Technical details (xcodes, realms, BU IDs)
+- Issue descriptions with realistic content
+- Rich text content with proper HTML formatting
+
+#### 4. Field Relationships
+- Respects read-only fields and skips them
+- Triggers proper change events to update dependent fields
+- Integrates with existing field synchronization logic
+- Updates subject lines automatically after population
+
+## Templates Updated
+
+### SIM Templates (9 total)
+1. `sim/achievement-levels.js`
+2. `sim/assessment-reports.js`
+3. `sim/assignment.js`
+4. `sim/dashboard.js`
+5. `sim/fsa.js`
+6. `sim/library-view.js`
+7. `sim/orr.js`
+8. `sim/plan-teach.js`
+9. `sim/reading-log.js`
+
+### Other Templates (4 total)
+1. `other/dpt.js`
+2. `other/feature-request.js`
+3. `other/help-article.js`
+4. `other/timeout-extension.js`
+
+### Assembly Templates (2 total)
+1. `assembly/assembly.js`
+2. `assembly/assembly-rollover.js`
+
+### SEDCUST Templates (1 total)
+1. `sedcust/sedcust.js`
+
+## Usage
+
+### For Users
+1. Open any template in the application
+2. Look for the "Fill Demo Data" button in the top-right corner
+3. Click the button to instantly populate all fields with sample data
+4. Review and modify the populated data as needed for testing
+
+### For Developers
+The demo data helper can be extended by:
+1. Adding new field-specific demo data to the `demoData` object
+2. Implementing custom field population logic in the `populateField` method
+3. Adding new field type support as needed
+
+## Technical Implementation
+
+### Integration Pattern
+Each template's `onLoad` function includes:
+```javascript
+// Add demo data functionality
+const demoDataHelper = new DemoDataHelper();
+const demoButton = demoDataHelper.addDemoDataButton();
+if (demoButton) {
+    demoButton.addEventListener('click', () => {
+        demoDataHelper.fillDemoData(module.exports);
+    });
+}
+```
+
+### Event Handling
+- Triggers appropriate input/change events after population
+- Integrates with existing template validation and update logic
+- Maintains compatibility with subject line formatting systems
+
+## Benefits
+
+1. **Faster Testing**: Eliminates manual data entry for testing purposes
+2. **Consistent Data**: Provides realistic, consistent test data across all templates
+3. **Quality Assurance**: Enables easier validation of form functionality
+4. **Developer Productivity**: Speeds up development and debugging workflows
+5. **Training**: Useful for training purposes to show examples of properly filled forms
+
+## Maintenance
+
+The demo data helper is designed to be:
+- **Extensible**: Easy to add new demo data or field types
+- **Maintainable**: Clear separation of concerns with dedicated utility class
+- **Compatible**: Works with existing template architecture without conflicts
+- **Reliable**: Includes error handling and fallback mechanisms
+
+## Future Enhancements
+
+Potential improvements could include:
+1. Template-specific demo data variations
+2. Multiple demo data sets (e.g., VIP vs Standard districts)
+3. Demo data export/import functionality
+4. Integration with actual test data sources

--- a/app/templates/assembly/assembly-rollover.js
+++ b/app/templates/assembly/assembly-rollover.js
@@ -1,4 +1,5 @@
 // Import utility functions that will be used in this template
+// - DemoDataHelper from app/utils/demoDataHelper.js
 // These need to be available globally in the browser environment
 // - formatDate from app/utils/formatDate.js
 // - populateApplicationName, populateDistrictState, populateVIPStatus from app/utils/fieldPopulators.js
@@ -548,6 +549,15 @@ module.exports = {
 
             // Execute the update
             updateSourceTicketTags();
+        }
+
+        // Add demo data functionality
+        const demoDataHelper = new DemoDataHelper();
+        const demoButton = demoDataHelper.addDemoDataButton();
+        if (demoButton) {
+            demoButton.addEventListener('click', () => {
+                demoDataHelper.fillDemoData(module.exports);
+            });
         }
     }
 }; 

--- a/app/templates/assembly/assembly.js
+++ b/app/templates/assembly/assembly.js
@@ -4,6 +4,7 @@
 // - populateApplicationName, populateDistrictState, populateVIPStatus from app/utils/fieldPopulators.js
 // - setupCustomVersionInput, setupCustomVersionStateInput, getVersionValue, getVersionStateValue from app/utils/versionFieldHandlers.js
 // - TemplateBase from app/utils/templateBase.js
+// - DemoDataHelper from app/utils/demoDataHelper.js
 
 module.exports = {
     title: "Assembly Tracker",
@@ -410,6 +411,15 @@ module.exports = {
 
             // Execute the update
             updateSourceTicketTags();
+        }
+
+        // Add demo data functionality
+        const demoDataHelper = new DemoDataHelper();
+        const demoButton = demoDataHelper.addDemoDataButton();
+        if (demoButton) {
+            demoButton.addEventListener('click', () => {
+                demoDataHelper.fillDemoData(module.exports);
+            });
         }
     }
 }; 

--- a/app/templates/other/dpt.js
+++ b/app/templates/other/dpt.js
@@ -1,4 +1,5 @@
 // Import utility functions that will be used in this template
+// - DemoDataHelper from app/utils/demoDataHelper.js
 // These need to be available globally in the browser environment
 // - formatDate from app/utils/formatDate.js
 // - populateApplicationName, populateDistrictState, populateVIPStatus from app/utils/fieldPopulators.js
@@ -331,5 +332,14 @@ module.exports = {
                 districtStateSummaryField.value = this.value;
             }
         });
+
+        // Add demo data functionality
+        const demoDataHelper = new DemoDataHelper();
+        const demoButton = demoDataHelper.addDemoDataButton();
+        if (demoButton) {
+            demoButton.addEventListener('click', () => {
+                demoDataHelper.fillDemoData(module.exports);
+            });
+        }
     }
 };

--- a/app/templates/other/feature-request.js
+++ b/app/templates/other/feature-request.js
@@ -4,6 +4,7 @@
 // - populateApplicationName, populateDistrictState, populateVIPStatus from app/utils/fieldPopulators.js
 // - setupCustomVersionInput, setupCustomVersionStateInput, getVersionValue, getVersionStateValue from app/utils/versionFieldHandlers.js
 // - TemplateBase from app/utils/templateBase.js
+// - DemoDataHelper from app/utils/demoDataHelper.js
 
 module.exports = {
     title: "Feature Request Tracker",
@@ -472,5 +473,14 @@ module.exports = {
 
         // Schedule another sync after a small delay to ensure fields are populated
         setTimeout(syncFeatureRequestFields, 500);
+
+        // Add demo data functionality
+        const demoDataHelper = new DemoDataHelper();
+        const demoButton = demoDataHelper.addDemoDataButton();
+        if (demoButton) {
+            demoButton.addEventListener('click', () => {
+                demoDataHelper.fillDemoData(module.exports);
+            });
+        }
     }
 };

--- a/app/templates/other/help-article.js
+++ b/app/templates/other/help-article.js
@@ -1,4 +1,5 @@
 // Import utility functions that will be used in this template
+// - DemoDataHelper from app/utils/demoDataHelper.js
 // These need to be available globally in the browser environment
 // - formatDate from app/utils/formatDate.js
 // - populateApplicationName, populateDistrictState from app/utils/fieldPopulators.js
@@ -167,5 +168,14 @@ module.exports = {
 
         // Schedule another sync after a small delay
         setTimeout(syncArticleName, 500);
+
+        // Add demo data functionality
+        const demoDataHelper = new DemoDataHelper();
+        const demoButton = demoDataHelper.addDemoDataButton();
+        if (demoButton) {
+            demoButton.addEventListener('click', () => {
+                demoDataHelper.fillDemoData(module.exports);
+            });
+        }
     }
 };

--- a/app/templates/other/timeout-extension.js
+++ b/app/templates/other/timeout-extension.js
@@ -1,4 +1,5 @@
 // Import utility functions that will be used in this template
+// - DemoDataHelper from app/utils/demoDataHelper.js
 // These need to be available globally in the browser environment
 // - formatDate from app/utils/formatDate.js
 // - populateApplicationName, populateDistrictState, populateVIPStatus from app/utils/fieldPopulators.js
@@ -336,6 +337,13 @@ module.exports = {
             toggleHarFileReason();
         }
 
-
+        // Add demo data functionality
+        const demoDataHelper = new DemoDataHelper();
+        const demoButton = demoDataHelper.addDemoDataButton();
+        if (demoButton) {
+            demoButton.addEventListener('click', () => {
+                demoDataHelper.fillDemoData(module.exports);
+            });
+        }
     }
 };

--- a/app/templates/sedcust/sedcust.js
+++ b/app/templates/sedcust/sedcust.js
@@ -4,6 +4,7 @@
 // - populateApplicationName, populateDistrictState, populateVIPStatus from app/utils/fieldPopulators.js
 // - setupCustomVersionInput, setupCustomVersionStateInput, getVersionValue, getVersionStateValue from app/utils/versionFieldHandlers.js
 // - TemplateBase from app/utils/templateBase.js
+// - DemoDataHelper from app/utils/demoDataHelper.js
 
 module.exports = {
     title: "Content/Editorial Tracker",
@@ -550,6 +551,15 @@ module.exports = {
 
             // Update priority when VIP status changes
             isVIPField.addEventListener('change', updatePriorityForVIP);
+        }
+
+        // Add demo data functionality
+        const demoDataHelper = new DemoDataHelper();
+        const demoButton = demoDataHelper.addDemoDataButton();
+        if (demoButton) {
+            demoButton.addEventListener('click', () => {
+                demoDataHelper.fillDemoData(module.exports);
+            });
         }
     }
 };

--- a/app/templates/sim/achievement-levels.js
+++ b/app/templates/sim/achievement-levels.js
@@ -4,6 +4,7 @@
 // - populateApplicationName, populateDistrictState from app/utils/fieldPopulators.js
 // - setupCustomVersionInput, setupCustomVersionStateInput, getVersionValue, getVersionStateValue from app/utils/versionFieldHandlers.js
 // - TemplateBase from app/utils/templateBase.js
+// - DemoDataHelper from app/utils/demoDataHelper.js
 
 module.exports = {
     title: "SIM Achievement Levels Tracker",
@@ -150,6 +151,15 @@ module.exports = {
             window.trackerApp.setupSmartsheetUploader();
         } else {
             console.warn("TrackerApp or setupSmartsheetUploader not available");
+        }
+
+        // Add demo data functionality
+        const demoDataHelper = new DemoDataHelper();
+        const demoButton = demoDataHelper.addDemoDataButton();
+        if (demoButton) {
+            demoButton.addEventListener('click', () => {
+                demoDataHelper.fillDemoData(module.exports);
+            });
         }
     }
 };

--- a/app/templates/sim/assessment-reports.js
+++ b/app/templates/sim/assessment-reports.js
@@ -1,4 +1,5 @@
 // Import utility functions that will be used in this template
+// - DemoDataHelper from app/utils/demoDataHelper.js
 // These need to be available globally in the browser environment
 // - formatDate from app/utils/formatDate.js
 // - populateApplicationName, populateDistrictState from app/utils/fieldPopulators.js
@@ -510,5 +511,14 @@ module.exports = {
 
             // Initial population in case resource is already selected
             setTimeout(populateReportName, 500);
+
+            // Add demo data functionality
+            const demoDataHelper = new DemoDataHelper();
+            const demoButton = demoDataHelper.addDemoDataButton();
+            if (demoButton) {
+                demoButton.addEventListener('click', () => {
+                    demoDataHelper.fillDemoData(module.exports);
+                });
+            }
         }
     };

--- a/app/templates/sim/assignment.js
+++ b/app/templates/sim/assignment.js
@@ -1,4 +1,5 @@
 // Import utility functions that will be used in this template
+// - DemoDataHelper from app/utils/demoDataHelper.js
 // These need to be available globally in the browser environment
 // - formatDate from app/utils/formatDate.js
 // - populateApplicationName, populateDistrictState from app/utils/fieldPopulators.js
@@ -367,7 +368,16 @@ module.exports = {
 
             templateBase.initializeSubjectLineFormatting();
 
-            // Schedule another update after a small delay to ensure fields are populated
-            setTimeout(() => templateBase.updateSubjectLine(), 500);
+                    // Schedule another update after a small delay to ensure fields are populated
+        setTimeout(() => templateBase.updateSubjectLine(), 500);
+
+        // Add demo data functionality
+        const demoDataHelper = new DemoDataHelper();
+        const demoButton = demoDataHelper.addDemoDataButton();
+        if (demoButton) {
+            demoButton.addEventListener('click', () => {
+                demoDataHelper.fillDemoData(module.exports);
+            });
         }
-    };
+    }
+};

--- a/app/templates/sim/dashboard.js
+++ b/app/templates/sim/dashboard.js
@@ -4,6 +4,7 @@
 // - populateApplicationName, populateDistrictState from app/utils/fieldPopulators.js
 // - setupCustomVersionInput, setupCustomVersionStateInput, getVersionValue, getVersionStateValue from app/utils/versionFieldHandlers.js
 // - TemplateBase from app/utils/templateBase.js
+// - DemoDataHelper from app/utils/demoDataHelper.js
 
 module.exports = {
         title: "SIM Dashboard Tracker",
@@ -355,7 +356,16 @@ module.exports = {
 
             templateBase.initializeSubjectLineFormatting();
 
-            // Schedule another update after a small delay to ensure fields are populated
-            setTimeout(() => templateBase.updateSubjectLine(), 500);
+                    // Schedule another update after a small delay to ensure fields are populated
+        setTimeout(() => templateBase.updateSubjectLine(), 500);
+
+        // Add demo data functionality
+        const demoDataHelper = new DemoDataHelper();
+        const demoButton = demoDataHelper.addDemoDataButton();
+        if (demoButton) {
+            demoButton.addEventListener('click', () => {
+                demoDataHelper.fillDemoData(module.exports);
+            });
         }
-    };
+    }
+};

--- a/app/templates/sim/fsa.js
+++ b/app/templates/sim/fsa.js
@@ -1,4 +1,5 @@
 // Import utility functions that will be used in this template
+// - DemoDataHelper from app/utils/demoDataHelper.js
 // These need to be available globally in the browser environment
 // - formatDate from app/utils/formatDate.js
 // - populateApplicationName, populateDistrictState from app/utils/fieldPopulators.js
@@ -351,7 +352,16 @@ module.exports = {
 
             templateBase.initializeSubjectLineFormatting();
 
-            // Schedule another update after a small delay to ensure fields are populated
-            setTimeout(() => templateBase.updateSubjectLine(), 500);
+                    // Schedule another update after a small delay to ensure fields are populated
+        setTimeout(() => templateBase.updateSubjectLine(), 500);
+
+        // Add demo data functionality
+        const demoDataHelper = new DemoDataHelper();
+        const demoButton = demoDataHelper.addDemoDataButton();
+        if (demoButton) {
+            demoButton.addEventListener('click', () => {
+                demoDataHelper.fillDemoData(module.exports);
+            });
         }
-    };
+    }
+};

--- a/app/templates/sim/library-view.js
+++ b/app/templates/sim/library-view.js
@@ -1,4 +1,5 @@
 // Import utility functions that will be used in this template
+// - DemoDataHelper from app/utils/demoDataHelper.js
 // These need to be available globally in the browser environment
 // - formatDate from app/utils/formatDate.js
 // - populateApplicationName, populateDistrictState from app/utils/fieldPopulators.js
@@ -315,7 +316,16 @@ module.exports = {
 
             templateBase.initializeSubjectLineFormatting();
 
-            // Schedule another update after a small delay to ensure fields are populated
-            setTimeout(() => templateBase.updateSubjectLine(), 500);
+                    // Schedule another update after a small delay to ensure fields are populated
+        setTimeout(() => templateBase.updateSubjectLine(), 500);
+
+        // Add demo data functionality
+        const demoDataHelper = new DemoDataHelper();
+        const demoButton = demoDataHelper.addDemoDataButton();
+        if (demoButton) {
+            demoButton.addEventListener('click', () => {
+                demoDataHelper.fillDemoData(module.exports);
+            });
         }
-    };
+    }
+};

--- a/app/templates/sim/orr.js
+++ b/app/templates/sim/orr.js
@@ -1,4 +1,5 @@
 // Import utility functions that will be used in this template
+// - DemoDataHelper from app/utils/demoDataHelper.js
 // These need to be available globally in the browser environment
 // - formatDate from app/utils/formatDate.js
 // - populateApplicationName, populateDistrictState from app/utils/fieldPopulators.js
@@ -320,7 +321,16 @@ module.exports = {
 
             templateBase.initializeSubjectLineFormatting();
 
-            // Schedule another update after a small delay to ensure fields are populated
-            setTimeout(() => templateBase.updateSubjectLine(), 500);
+                    // Schedule another update after a small delay to ensure fields are populated
+        setTimeout(() => templateBase.updateSubjectLine(), 500);
+
+        // Add demo data functionality
+        const demoDataHelper = new DemoDataHelper();
+        const demoButton = demoDataHelper.addDemoDataButton();
+        if (demoButton) {
+            demoButton.addEventListener('click', () => {
+                demoDataHelper.fillDemoData(module.exports);
+            });
         }
-    };
+    }
+};

--- a/app/templates/sim/plan-teach.js
+++ b/app/templates/sim/plan-teach.js
@@ -1,4 +1,5 @@
 // Import utility functions that will be used in this template
+// - DemoDataHelper from app/utils/demoDataHelper.js
 // These need to be available globally in the browser environment
 // - formatDate from app/utils/formatDate.js
 // - populateApplicationName, populateDistrictState from app/utils/fieldPopulators.js
@@ -379,7 +380,16 @@ module.exports = {
 
             templateBase.initializeSubjectLineFormatting();
 
-            // Schedule another update after a small delay to ensure fields are populated
-            setTimeout(() => templateBase.updateSubjectLine(), 500);
+                    // Schedule another update after a small delay to ensure fields are populated
+        setTimeout(() => templateBase.updateSubjectLine(), 500);
+
+        // Add demo data functionality
+        const demoDataHelper = new DemoDataHelper();
+        const demoButton = demoDataHelper.addDemoDataButton();
+        if (demoButton) {
+            demoButton.addEventListener('click', () => {
+                demoDataHelper.fillDemoData(module.exports);
+            });
         }
-    };
+    }
+};

--- a/app/templates/sim/reading-log.js
+++ b/app/templates/sim/reading-log.js
@@ -1,4 +1,5 @@
 // Import utility functions that will be used in this template
+// - DemoDataHelper from app/utils/demoDataHelper.js
 // These need to be available globally in the browser environment
 // - formatDate from app/utils/formatDate.js
 // - populateApplicationName, populateDistrictState from app/utils/fieldPopulators.js
@@ -393,7 +394,16 @@ module.exports = {
 
             templateBase.initializeSubjectLineFormatting();
 
-            // Schedule another update after a small delay to ensure fields are populated
-            setTimeout(() => templateBase.updateSubjectLine(), 500);
+                    // Schedule another update after a small delay to ensure fields are populated
+        setTimeout(() => templateBase.updateSubjectLine(), 500);
+
+        // Add demo data functionality
+        const demoDataHelper = new DemoDataHelper();
+        const demoButton = demoDataHelper.addDemoDataButton();
+        if (demoButton) {
+            demoButton.addEventListener('click', () => {
+                demoDataHelper.fillDemoData(module.exports);
+            });
         }
-    };
+    }
+};

--- a/app/utils/demoDataHelper.js
+++ b/app/utils/demoDataHelper.js
@@ -1,0 +1,303 @@
+/**
+ * Demo Data Helper Utility
+ * Provides demo data generation and form population functionality for templates
+ */
+
+class DemoDataHelper {
+    constructor() {
+        this.demoData = {
+            // Basic text fields
+            districtName: "Fairfax County Public Schools",
+            districtState: "VA",
+            application: "Advance -c2022",
+            username: "jsmith123",
+            userEmail: "jane.smith@fairfaxschools.org",
+            name: "Jane Smith",
+            userRole: "Teacher",
+            role: "Teacher",
+            realm: "msemail",
+            schoolName: "Thomas Jefferson Elementary",
+            xcode: "X98765",
+            resource: "TRS",
+            resourceName: "TRS",
+            specificIssue: "Unit 5 Assessment Not Loading",
+            shortDescription: "Unable to Access Digital Resources",
+            shortDescriptionDetails: "Unable to Access Digital Resources",
+            path: "G3>U5>W1>L15",
+            pathField: "Advance -c2022 > TRS: G3>U5>W1>L15",
+            gradesImpacted: "Grade 3",
+            dateReported: this.getTodayDate(),
+            dateRequested: this.getTodayDate(),
+            device: "Chromebook",
+            studentInternalId: "12345678",
+            BURCLink: "https://onboarding-production.benchmarkuniverse.com/85066/dashboard",
+            customer_email: "jane.smith@fairfaxschools.org",
+            
+            // Rich text fields
+            issueDescription: "<p>Students are unable to access the Unit 5 assessment in the TRS. When clicking on the assessment link, the page loads indefinitely without displaying content. This is affecting all students in Grade 3.</p>",
+            stepsToReproduce: "<p>1. Log into student account<br>2. Navigate to TRS<br>3. Click on Grade 3<br>4. Select Unit 5<br>5. Click on Week 1 Assessment<br>6. Page fails to load</p>",
+            expectedResults: "<p>The Unit 5 assessment should load properly and display all questions for students to complete within the expected timeframe.</p>",
+            actualResults: "<p>The assessment page shows a loading spinner indefinitely and never displays the actual assessment content. Students cannot proceed with their work.</p>",
+            additionalDetails: "<p>This issue started occurring on Monday morning and affects approximately 150 students across 6 different classes. Teachers have tried refreshing browsers and using different devices with the same result.</p>",
+            screenshotsDescription: "<p>Screenshots of the loading error have been attached showing the stuck loading state.</p>",
+            summary: "<p>Students cannot access Grade 3 Unit 5 assessment in TRS - page loads indefinitely affecting 150+ students across multiple classes.</p>",
+            summaryContent: "<p>Fairfax County Public Schools is requesting custom achievement levels.</p>",
+            issueSummary: "<p>In Advance -c2022 TRS: G3 > U5 > W1 > Assessment, the assessment fails to load properly for students.</p>",
+            issueDetails: "<p>Multiple teachers have reported that their Grade 3 students cannot access the Unit 5 Week 1 assessment. The issue appears to be system-wide affecting all classes using this specific assessment.</p>",
+            components: "<p>TRS (Teacher Resource System) - eAssessment component</p>",
+            subscriptionCodes: "<p>BEC Benchmark Advance 2022 (National Edition) Gr. 3 Classroom Digital<br>BEC Benchmark Advance 2022 (Virginia Edition) Gr. 3 Student Digital</p>",
+            
+            // Select field options
+            isVIP: "No",
+            version: "2.75",
+            versionState: "Virginia",
+            harFileAttached: "Yes",
+            hasMultipleXcodes: "No",
+            impactScope: "Both Teacher and Student",
+            impactType: "Digital Only",
+            team: "SIM (Colleen Baker)"
+        };
+    }
+
+    getTodayDate() {
+        return new Date().toISOString().split('T')[0];
+    }
+
+    /**
+     * Get demo data for a specific field
+     */
+    getDemoValue(fieldId, fieldType, options = []) {
+        if (this.demoData[fieldId]) {
+            return this.demoData[fieldId];
+        }
+
+        // Generate data based on type if no specific demo data exists
+        switch (fieldType) {
+            case 'text':
+                return this.generateTextDemo(fieldId);
+            case 'email':
+                return "demo.user@testschool.edu";
+            case 'date':
+                return this.getTodayDate();
+            case 'select':
+                return this.getSelectDemo(options);
+            case 'richtext':
+                return "<p>Demo content for testing purposes - this field contains sample data to help with form validation and testing.</p>";
+            default:
+                return "";
+        }
+    }
+
+    generateTextDemo(fieldId) {
+        const demos = {
+            default: "Demo Text Value",
+            districtName: "Sample School District",
+            schoolName: "Demo Elementary School", 
+            username: "demo.user",
+            name: "Demo User",
+            xcode: "X12345",
+            path: "G1>U1>W1>L1",
+            specificIssue: "Sample Issue Description"
+        };
+        return demos[fieldId] || demos.default;
+    }
+
+    getSelectDemo(options) {
+        if (options && options.length > 1) {
+            // Skip empty first option and loading options
+            const validOptions = options.filter(opt => 
+                opt && opt !== "" && opt !== "-- Loading from settings --"
+            );
+            if (validOptions.length > 0) {
+                return validOptions[0];
+            }
+        }
+        return "";
+    }
+
+    /**
+     * Fill all form fields with demo data
+     */
+    fillDemoData(template) {
+        console.log("Filling demo data for template:", template.title);
+        
+        if (!template.sections) {
+            console.warn("Template has no sections to populate");
+            return;
+        }
+
+        let fieldsPopulated = 0;
+
+        template.sections.forEach(section => {
+            if (section.fields) {
+                section.fields.forEach(field => {
+                    if (field.type === 'hidden') return; // Skip hidden fields
+                    
+                    const element = document.getElementById(field.id);
+                    if (!element) {
+                        console.warn(`Field element not found: ${field.id}`);
+                        return;
+                    }
+
+                    // Skip read-only fields
+                    if (field.readOnly || element.readOnly) {
+                        console.log(`Skipping read-only field: ${field.id}`);
+                        return;
+                    }
+
+                    try {
+                        this.populateField(field, element);
+                        fieldsPopulated++;
+                    } catch (error) {
+                        console.error(`Error populating field ${field.id}:`, error);
+                    }
+                });
+            }
+        });
+
+        console.log(`Demo data population complete. ${fieldsPopulated} fields populated.`);
+
+        // Trigger any field change events to update dependent fields
+        this.triggerFieldUpdates();
+    }
+
+    populateField(field, element) {
+        switch (field.type) {
+            case 'text':
+            case 'email':
+                element.value = this.getDemoValue(field.id, field.type);
+                element.dispatchEvent(new Event('input', { bubbles: true }));
+                break;
+
+            case 'date':
+                element.value = this.getDemoValue(field.id, field.type);
+                element.dispatchEvent(new Event('change', { bubbles: true }));
+                break;
+
+            case 'select':
+                const selectValue = this.getDemoValue(field.id, field.type, field.options);
+                if (selectValue && Array.from(element.options).some(opt => opt.value === selectValue)) {
+                    element.value = selectValue;
+                    element.dispatchEvent(new Event('change', { bubbles: true }));
+                } else if (element.options.length > 1) {
+                    // Select first non-empty option
+                    for (let option of element.options) {
+                        if (option.value && option.value !== "" && option.value !== "-- Loading from settings --") {
+                            element.value = option.value;
+                            element.dispatchEvent(new Event('change', { bubbles: true }));
+                            break;
+                        }
+                    }
+                }
+                break;
+
+            case 'checkboxes':
+                if (field.options && field.options.length > 0) {
+                    // Check the first checkbox option
+                    const firstCheckbox = document.querySelector(`input[name="${field.id}"][value="${field.options[0].id}"]`);
+                    if (firstCheckbox) {
+                        firstCheckbox.checked = true;
+                        firstCheckbox.dispatchEvent(new Event('change', { bubbles: true }));
+                    }
+                }
+                break;
+
+            case 'richtext':
+                // Handle Quill editor
+                const quillContainer = element.closest('.ql-container');
+                if (quillContainer && window.Quill) {
+                    const quill = quillContainer.__quill || window.quillInstances?.[field.id];
+                    if (quill) {
+                        const demoContent = this.getDemoValue(field.id, field.type);
+                        quill.root.innerHTML = demoContent;
+                        quill.history.clear();
+                    }
+                } else {
+                    // Fallback for regular textarea
+                    element.value = this.getDemoValue(field.id, field.type);
+                    element.dispatchEvent(new Event('input', { bubbles: true }));
+                }
+                break;
+
+            default:
+                console.warn(`Unknown field type: ${field.type} for field ${field.id}`);
+        }
+    }
+
+    triggerFieldUpdates() {
+        // Trigger updates after a small delay to ensure all fields are populated
+        setTimeout(() => {
+            // Trigger common update events
+            const updateEvents = ['input', 'change'];
+            const commonFields = ['districtName', 'districtState', 'application', 'version', 'versionState'];
+            
+            commonFields.forEach(fieldId => {
+                const element = document.getElementById(fieldId);
+                if (element) {
+                    updateEvents.forEach(eventType => {
+                        element.dispatchEvent(new Event(eventType, { bubbles: true }));
+                    });
+                }
+            });
+
+            // Update subject line if template has this functionality
+            if (window.templateBase && typeof window.templateBase.updateSubjectLine === 'function') {
+                window.templateBase.updateSubjectLine();
+            }
+        }, 100);
+    }
+
+    /**
+     * Create and add demo data button to template
+     */
+    addDemoDataButton(containerId = 'templateContainer') {
+        const container = document.getElementById(containerId) || document.body;
+        
+        // Check if button already exists
+        if (document.getElementById('demoDataButton')) {
+            return;
+        }
+
+        const button = document.createElement('button');
+        button.id = 'demoDataButton';
+        button.className = 'btn btn-secondary btn-sm';
+        button.innerHTML = '<i class="fa fa-flask"></i> Fill Demo Data';
+        button.title = 'Fill all fields with demo data for testing';
+        button.style.cssText = `
+            position: fixed;
+            top: 20px;
+            right: 20px;
+            z-index: 9999;
+            background-color: #6c757d;
+            border-color: #6c757d;
+            color: white;
+            padding: 8px 16px;
+            border-radius: 4px;
+            border: none;
+            font-size: 12px;
+            cursor: pointer;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        `;
+
+        // Add hover effects
+        button.addEventListener('mouseenter', () => {
+            button.style.backgroundColor = '#5a6268';
+            button.style.borderColor = '#545b62';
+        });
+
+        button.addEventListener('mouseleave', () => {
+            button.style.backgroundColor = '#6c757d';
+            button.style.borderColor = '#6c757d';
+        });
+
+        container.appendChild(button);
+        return button;
+    }
+}
+
+// Export for use in templates
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = DemoDataHelper;
+} else {
+    window.DemoDataHelper = DemoDataHelper;
+}


### PR DESCRIPTION
A `DemoDataHelper` class was created in `app/utils/demoDataHelper.js` to provide intelligent demo data generation. This helper populates various field types, including text, select, checkboxes, richtext, date, and email, with realistic sample data. It also dynamically adds a floating "Fill Demo Data" button to the top-right of the template.

This functionality was integrated into the `onLoad` function of all 16 templates within `@/templates`, specifically in `sim/`, `assembly/`, `other/`, and `sedcust/` directories. The integration ensures the button appears once the template is fully loaded. Clicking the button populates all visible form fields, respecting read-only states, and triggers necessary change events for UI updates, such as subject line formatting. A `DEMO_DATA_IMPLEMENTATION.md` document was also created to summarize the implementation.